### PR TITLE
Новое представление для get favorites и watchlist

### DIFF
--- a/morec/api/serializers/movies.py
+++ b/morec/api/serializers/movies.py
@@ -53,6 +53,21 @@ class MoviesListSerializer(
         return obj.premiere_date.year
 
 
+class MoviesFavoritsAndWatchlistSerializer(MoviesListSerializer):
+    class Meta:
+        model = Movie
+        fields = (
+            'id',
+            'title',
+            'h_picture',
+            'rating',
+            'year',
+            'genres',
+            'is_favorite',
+            'is_need_see',
+        )
+
+
 class MoviesDetailSerializer(
     RateInMovieMixin,
     IsFavoriteMixin,

--- a/morec/api/views/movies.py
+++ b/morec/api/views/movies.py
@@ -14,6 +14,7 @@ from rest_framework.viewsets import GenericViewSet
 from api.filters import MoviesFilter
 from api.serializers.movies import (MovieRateSerializer,
                                     MoviesDetailSerializer,
+                                    MoviesFavoritsAndWatchlistSerializer,
                                     MoviesListSerializer,
                                     MoviesOfDaySerializer)
 from movies.models import Movie, RatingMovie
@@ -36,8 +37,8 @@ class MoviesViewSet(RetrieveModelMixin, ListModelMixin, GenericViewSet):
         'newest': MoviesListSerializer,
         'rated': MoviesListSerializer,
         'rate': MovieRateSerializer,
-        'favorites': MoviesListSerializer,
-        'watchlist': MoviesListSerializer,
+        'favorites': MoviesFavoritsAndWatchlistSerializer,
+        'watchlist': MoviesFavoritsAndWatchlistSerializer,
         'recomendations': MoviesListSerializer,
         'movies_of_the_day': MoviesOfDaySerializer,
     }


### PR DESCRIPTION
Исправлен баг:
Добавлен сериализатор отнаследованный от MoviesListSerializer с указанием нового набора полей отдаваемого при запросе favorites и watchlist, чтобы не возвращало лишнее поле 'v_picture'